### PR TITLE
removed connman.RequestName() in NewAgent() and changed agent name

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -3,7 +3,6 @@ package connman
 import (
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/godbus/dbus"
 )
@@ -26,16 +25,6 @@ func NewAgent(psk string) *Agent {
 	conn, err := dbus.SystemBus()
 	if err != nil {
 		fmt.Println(err)
-		return nil
-	}
-
-	reply, err := conn.RequestName(agent.Name, dbus.NameFlagDoNotQueue)
-	if err != nil {
-		fmt.Println(err)
-		return nil
-	}
-	if reply != dbus.RequestNameReplyPrimaryOwner {
-		fmt.Fprintln(os.Stderr, "Name already taken")
 		return nil
 	}
 

--- a/agent.go
+++ b/agent.go
@@ -17,8 +17,8 @@ type Agent struct {
 
 func NewAgent(psk string) *Agent {
 	agent := &Agent{
-		Name:       "com.develboard.webadmin",
-		Path:       "/com/develboard/webadmin/Agent",
+		Name:       "net.connman",
+		Path:       "/test/agent",
 		Interface:  "net.connman.Agent",
 		Passphrase: psk,
 	}


### PR DESCRIPTION
Hi Pietro,

we have tried to use gonnman and made these changes to be able to connect to a wifi.
It turned out removing the connman.RequestName() is necessary to connect.
However, is that correct?
