### PR TITLE
Fixes for connman 1.36

### DIFF
--- a/dbus.go
+++ b/dbus.go
@@ -91,6 +91,7 @@ func DBusTechnology(tech dbus.ObjectPath) (*DBusInterface, error) {
 
 func setField(dst interface{}, key string, val dbus.Variant) error {
 	key = strings.Replace(key, ".", "", -1)
+	key = strings.Title(key)
 
 	sv := reflect.ValueOf(dst).Elem()
 	sfv := sv.FieldByName(key)

--- a/service.go
+++ b/service.go
@@ -54,6 +54,8 @@ type Service struct {
 	AutoConnect bool
 	Immutable   bool
 	Roaming     bool
+	MDNS   		bool
+	MDNSConfiguration bool
 
 	Ethernet           EthConfig
 	IPv4               IPv4Config


### PR DESCRIPTION
Connman 1.36 adds the fields mDNS and mDNS.Configuration to services.  

- service.go: Added new keys
- dbus.go: mDNS is not capitalized in Connman, ensures all keys are capitalized